### PR TITLE
Update action runtime to Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,5 @@ outputs:
       The unique ID of the github release from which the assets were deleted.
 
 runs:
-  using: node16
+  using: node20
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,5 @@ outputs:
       The unique ID of the github release from which the assets were deleted.
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
## Summary
- change the JavaScript action runtime in action.yml from node20 to node24
- align the action with GitHub Actions runner runtime deprecation guidance

## Context
GitHub announced the Node 20 deprecation for JavaScript actions on GitHub-hosted runners:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This branch only updates the declared runtime in action metadata.